### PR TITLE
Update recline.view.ChoroplethMap.js

### DIFF
--- a/recline.view.ChoroplethMap.js
+++ b/recline.view.ChoroplethMap.js
@@ -558,7 +558,10 @@ this.recline.View = this.recline.View || {};
       });
       if (n > 0) {
         n = self.avg ? n : 1;
-        v = parseInt(v / n, 10);
+        v = parseFloat(v/n);
+      }
+      if (v% 1 != 0) {
+        v = v.toFixed(2);
       }
 
       return Mustache.render(


### PR DESCRIPTION
This PR allows for decimals up to two places for the hover label.

Before this PR a number like .57 would show as 0.
### Acceptance test

Decimals should show up in the label like the following picture:
![screen shot 2014-11-12 at 8 56 21 am](https://cloud.githubusercontent.com/assets/512243/5012219/ea3a4f06-6a49-11e4-8569-30887d080229.png)
