### PR TITLE
Replace discontinued MapQuest Open tiles by OpenStreetMap.org tiles.

### DIFF
--- a/recline.view.ChoroplethMap.js
+++ b/recline.view.ChoroplethMap.js
@@ -484,10 +484,9 @@ this.recline.View = this.recline.View || {};
       var self = this;
       this.map = new L.Map(this.$map.get(0));
 
-      var mapUrl = "//otile{s}-s.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png";
-      var osmAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="//developer.mapquest.com/content/osm/mq_logo.png">';
-
-      var bg = new L.TileLayer(mapUrl, {maxZoom: 18, attribution: osmAttribution ,subdomains: '1234'});
+      var mapUrl = "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
+      var osmAttribution = '©<a href="http://openstreetmap.org" target="_blank">OpenStreetMap</a> contributors';
+      var bg = new L.TileLayer(mapUrl, {maxZoom: 19, attribution: osmAttribution});
       this.map.addLayer(bg);
 
       // Create control to hold poly data.


### PR DESCRIPTION
This fix is identical fix to the one in upstream recline library: https://github.com/okfn/recline/pull/501/commits/3df0c2a2bb8897124bdbbca715b2be1fd99cb08f
